### PR TITLE
replace `node.doc` with `node.doc_node` in method `_process_for_docstring`

### DIFF
--- a/pylint_quotes/checker.py
+++ b/pylint_quotes/checker.py
@@ -156,7 +156,7 @@ class StringQuoteChecker(BaseTokenChecker):
             node_type: the type of node being operated on.
         """
         # if there is no docstring, don't need to do anything.
-        if node.doc is not None:
+        if node.doc_node is not None:
 
             # the module is everything, so to find the docstring, we
             # iterate line by line from the start until the first element


### PR DESCRIPTION
This PR fixes 4nds/pylint-quotes#2.

It resolves `AttributeError: 'Module' object has no attribute 'doc'` in

https://github.com/GITAI/pylint-quotes/blob/c9aae00800289e7bf89a13ba81950334aff5668f/pylint_quotes/checker.py#L159

Attribute `doc` was [depreciated](https://pylint.pycqa.org/projects/astroid/en/latest/changelog.html#what-s-new-in-astroid-2-11-0) since Astroid `2.11.0`,

> Accessing the doc attribute of `nodes.Module`, `nodes.ClassDef`, and `nodes.FunctionDef` has been deprecated in favour of the `doc_node` attribute. Note: `doc_node` is an (optional) `nodes.Const` whereas `doc` was an (optional) `str`.

and later [removed](https://pylint.pycqa.org/projects/astroid/en/latest/changelog.html#what-s-new-in-astroid-3-0-0) in Astroid `3.0.0`,

> Remove deprecated `doc` attribute for `Module`, `ClassDef`, and `FunctionDef`. Use the `doc_node` attribute instead.

This PR replaces `node.doc` with `node.doc_node` in method `_process_for_docstring` of class `StringQuoteChecker`.
